### PR TITLE
Add pip proxy support and support for xenial

### DIFF
--- a/lib/charms/layer/venv.py
+++ b/lib/charms/layer/venv.py
@@ -1,5 +1,6 @@
 from subprocess import check_call
 from pathlib import Path
+from os import environ
 
 from charmhelpers.core.hookenv import log, application_name
 from charms.reactive import not_unless
@@ -7,15 +8,15 @@ from charms.reactive import not_unless
 from charms.layer import options
 
 
-_cfg = options.get('venv')
+_cfg = options.get("venv")
 
-ENV_NAME = _cfg['env_name'] if _cfg['env_name'] else application_name()
-log(f'ENV_NAME: {ENV_NAME}')
-ENV_DIR = Path('/opt/juju_venvs') / ENV_NAME
-ENV_BIN = ENV_DIR / 'bin'
+ENV_NAME = _cfg["env_name"] if _cfg["env_name"] else application_name()
+log("ENV_NAME: {}".format(ENV_NAME))
+ENV_DIR = Path("/opt/juju_venvs") / ENV_NAME
+ENV_BIN = ENV_DIR / "bin"
 
 
-@not_unless('venv.active')
+@not_unless("venv.active")
 def call_from_env(args):
     """
     Run command with arguments from inside the venv. Wait for command
@@ -23,13 +24,19 @@ def call_from_env(args):
     raise CalledProcessError. The CalledProcessError object will have
     the return code in the returncode attribute.
     """
-    cmd = ' '.join(args)
-    log(f'Running {cmd} from venv')
-    check_call(['bash', '-c', f'source {ENV_DIR}/bin/activate\n{cmd}'])
+    cmd = " ".join(args)
+    log("Running {} from venv".format(cmd))
+    check_call(". {}/activate; {}".format(ENV_BIN, cmd), shell=True)
 
 
 def pip_install(package):
     """
-    Installs the give pip package from the env
+    Installs the given pip package from the env
+    PIP uses https for upstream package downloads.
+    Use the JUJU_HTTPS_PROXY if available.
     """
-    call_from_env(['pip', 'install', package])
+    cmd = []
+    if "JUJU_CHARM_HTTPS_PROXY" in environ:
+        cmd = ["https_proxy={}".format(environ["JUJU_CHARM_HTTPS_PROXY"])]
+    cmd.extend(["pip", "install", package])
+    call_from_env(cmd)

--- a/reactive/venv.py
+++ b/reactive/venv.py
@@ -1,33 +1,53 @@
+import distro
 from subprocess import check_call
 
 from charmhelpers.core import hookenv
 from charmhelpers.core.hookenv import log
-
-from charms.reactive import set_flag
-
+from charms.reactive import set_flag, clear_flag, when, when_not, helpers
 from charms.layer import options
-from charms.layer.venv import pip_install, ENV_DIR, ENV_NAME
+
+from charms.layer.venv import pip_install, ENV_DIR, ENV_NAME, ENV_BIN
 
 
+@when_not("venv.active")
 def init():
-    log('Initializing venv layer')
-    cfg = options.get('venv')
-
+    log("Initializing venv layer")
     if not ENV_DIR.exists():
         ENV_DIR.mkdir(mode=0o755, parents=True, exist_ok=True)
+
+    if not ENV_BIN.exists():
         # pip does not install properly to venvs created inside
         # the charm env, so we use the system-installed python
         # as a work around.
-        check_call(['/usr/bin/python3', '-m', 'venv',
-                    '--prompt', ENV_NAME, str(ENV_DIR)])
+
+        # On Ubuntu older than bionic, venv doesn't support --prompt
+        if distro.id() == "ubuntu" and int(distro.version_parts()[0]) < 18:
+            check_call(["/usr/bin/python3", "-m", "venv", str(ENV_DIR)])
+        else:
+            check_call(["/usr/bin/python3", "-m", "venv", "--prompt", ENV_NAME, str(ENV_DIR)])
 
     # venv.create(str(ENV_DIR), with_pip=True)
-    set_flag('venv.active')
+    set_flag("venv.active")
 
-    for package in cfg['packages']:
+
+@when("venv.active", "venv.ready")
+def reconfigure():
+    cfg = options.get("venv")
+    if "packages" in cfg:
+        if helpers.data_changed("venv-packages", cfg["packages"]):
+            clear_flag("venv.ready")
+    if helpers.data_changed("venv-name", ENV_NAME):
+        clear_flag("venv.active")
+
+
+@when("venv.active")
+@when_not("venv.ready")
+def add_pip_to_venv():
+    cfg = options.get("venv")
+    for package in cfg["packages"]:
         pip_install(package)
 
-    set_flag('venv.ready')
+    set_flag("venv.ready")
 
 
 hookenv.atstart(init)


### PR DESCRIPTION
Add support for JUJU_CHARM_HTTPS_PROXY during pip install
Update venv creation to support ubuntu xenial
 - Update string formatting to support older versions of python3
 - Update venv call to not use the --prompt flag for ubunt older than bionic
Updated layer-venv to be reactive to changes in layer config between charm revs
General code cleanup and simplification

Addresses issues #2, #3, and #4